### PR TITLE
General: Fix layout issues on narrow screens.

### DIFF
--- a/compat.css
+++ b/compat.css
@@ -545,6 +545,23 @@ progress {
 	background-color:#455556;
 }
 @media screen and (max-width:1000px) {
+	.compat-search-outer {
+		display: grid;
+		grid-template-columns: repeat(15, 1fr);
+		grid-template-rows: 50% 50%;
+		height: 60px;
+		gap: 0;
+	}
+	.compat-search-inner {
+		font-size:14px;
+		width: auto;
+		height: 25px;
+	}
+	.compat-search-character {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
 	.compat-menu {
 		display: flex;
 		gap: 2%;
@@ -557,7 +574,6 @@ progress {
 	}
 	.compat-hdr-right {
 		width:100%;
-		padding-top:6px;
 		display: grid;
 		grid-template-columns: 32% 33% 32%;
 		grid-template-rows: 50% 50%;
@@ -566,6 +582,7 @@ progress {
 	}
 	.compat-hdr-right a {
 		font-size: 12px;
+		margin-bottom: 10px;
 	}
 	.compat-hdr-right .highlightedText {
 		font-size:12px;

--- a/compat.css
+++ b/compat.css
@@ -545,6 +545,13 @@ progress {
 	background-color:#455556;
 }
 @media screen and (max-width:1000px) {
+	.compat-menu {
+		display: flex;
+		gap: 2%;
+		float: none;
+		margin: 0;
+		margin-top: 20px;
+	}
 	.compat-hdr-left {
 		margin-bottom:40px
 	}

--- a/compat.css
+++ b/compat.css
@@ -564,11 +564,22 @@ progress {
 		font-size:12px;
 		font-weight:700
 	}
-	.compat-status-progressbar {
-		opacity:0.3;
+	.compat-status-container {
+		display: grid;
+		display: flex;
+		flex-direction: column;
+		gap: 1%;
+	}
+	.compat-status-progress {
+		visibility: hidden;
+	}
+	.compat-status-main {
+		overflow-x: scroll;
+		overflow-y: hidden;
+		width: auto;
 	}
 	.compat-status-text {
-		font-size:12px
+		font-size:12px;
 	}
 	.page-con-container {
 		margin:auto 15px

--- a/compat.css
+++ b/compat.css
@@ -550,7 +550,15 @@ progress {
 	}
 	.compat-hdr-right {
 		width:100%;
-		padding-top:6px
+		padding-top:6px;
+		display: grid;
+		grid-template-columns: 32% 33% 32%;
+		grid-template-rows: 50% 50%;
+		gap: 1%;
+		float: none;
+	}
+	.compat-hdr-right a {
+		font-size: 12px;
 	}
 	.compat-hdr-right .highlightedText {
 		font-size:12px;

--- a/compat.css
+++ b/compat.css
@@ -545,6 +545,7 @@ progress {
 	background-color:#455556;
 }
 @media screen and (max-width:1000px) {
+
 	.compat-search-outer {
 		display: grid;
 		grid-template-columns: repeat(15, 1fr);


### PR DESCRIPTION
This pull request changes several things in order to fix layout issues on narrow screens. To this end:

1. Compatibility menu buttons now don't float to right, instead they're positioned under the page title.
2. Compatibility status filter buttons now don't float to right, instead they're positioned under the preceding paragraph and are placed inside a 3x2 grid.
3. Compatibility status progress containers now don't display the status bar and the container divs themselves are scrollable on the x-axis in order for the text to be readable.
4. Compatibility table filter options are now placed within a 15x2 grid.

Please keep in mind all of these changes are made within the 1000px screen width media query.

Apologies for the lack of descriptive commits in the branch, I was sure I made more commits than those with more descriptive titles but it looks like I never actually made those commits before clearing my terminal screen.