### PR TITLE
Responsiveness fixes

### DIFF
--- a/compat.css
+++ b/compat.css
@@ -821,6 +821,15 @@ progress[value]::-webkit-progress-value {
     .compat-table-cell {
         min-width: 100px;
     }
+    
+    .compat-footer {
+        height: auto;
+    }
+    
+    .compat-footer p {
+        overflow-wrap: break-word;
+        line-height: 25px;
+    }
 }
 
 .highlightedText {

--- a/compat.css
+++ b/compat.css
@@ -813,6 +813,14 @@ progress[value]::-webkit-progress-value {
     .page-con-container {
         margin: auto 15px
     }
+    
+    .compat-table-row{
+        overflow-x: scroll;
+    }
+    
+    .compat-table-cell {
+        min-width: 100px;
+    }
 }
 
 .highlightedText {

--- a/compat.css
+++ b/compat.css
@@ -728,6 +728,13 @@ progress[value]::-webkit-progress-value {
 
 @media screen and (max-width: 1000px) {
     
+    .banner-tx2-title > p{
+        width:25%;
+        overflow-wrap: break-word;
+        margin-left: 37.5%;
+        line-height: 25px;
+    }
+    
     .compat-search-outer {
         display:grid;
         grid-template-columns: repeat(15,1fr);

--- a/compat.css
+++ b/compat.css
@@ -727,6 +727,7 @@ progress[value]::-webkit-progress-value {
 }
 
 @media screen and (max-width: 1000px) {
+    
     .compat-search-outer {
         display:grid;
         grid-template-columns: repeat(15,1fr);
@@ -770,7 +771,9 @@ progress[value]::-webkit-progress-value {
 
     .compat-hdr-right a {
         font-size: 12px;
-        margin-bottom: 10px
+        margin-bottom: 10px;
+        height: 25px;
+        line-height: 15px;
     }
 
     .compat-hdr-right .highlightedText {

--- a/compat.css
+++ b/compat.css
@@ -773,7 +773,7 @@ progress[value]::-webkit-progress-value {
     .compat-hdr-right a {
         font-size: 12px;
         margin-bottom: 10px;
-        height: 25px;
+        height: auto;
         line-height: 15px;
     }
 

--- a/compat.css
+++ b/compat.css
@@ -733,7 +733,8 @@ progress[value]::-webkit-progress-value {
         grid-template-columns: repeat(15,1fr);
         grid-template-rows: 50% 50%;
         height: 60px;
-        gap: 0
+        gap: 0;
+        border-radius: 10px;
     }
 
     .compat-search-inner {

--- a/compat.css
+++ b/compat.css
@@ -729,9 +729,9 @@ progress[value]::-webkit-progress-value {
 @media screen and (max-width: 1000px) {
     
     .banner-tx2-title > p{
-        width:25%;
+        width:30%;
         overflow-wrap: break-word;
-        margin-left: 37.5%;
+        margin-left: 35%;
         line-height: 25px;
     }
     


### PR DESCRIPTION
This PR achieves the following:

- Currently, the status filter buttons will overflow out of their backgrounds and become unreadable (white text on white background) on narrow screens, this is fixed with shorter line lengths and auto height.
- Currently, the alphabetical filter buttons (the first one and the last one on the first row) are cut off by the round edges, this is fixed by reducing rounding to match the table itself.
- Currently, the text under the banner goes outside screen bounds in narrow screens, this is fixed by wrapping the text and offsetting it to center.
- Currently, the table rows are not inline with one another, and not readable. This is fixed by giving table cells a minimum of 100px width. This ensures the following information are always visible and in-line on screens as narrow as 300px; software code, software name and software status.
- Currently, the footer is not readable on narrow screens, this is fixed by allowing the footer background to expand in height and wrapping the text.